### PR TITLE
retry instance tagging if the instance is not available

### DIFF
--- a/cloudcompose/image/aws/cloudcontroller.py
+++ b/cloudcompose/image/aws/cloudcontroller.py
@@ -197,7 +197,8 @@ class CloudController:
         return unused_image_ids
 
     def _is_retryable_exception(exception):
-        return not isinstance(exception, botocore.exceptions.ClientError)
+        return not isinstance(exception, botocore.exceptions.ClientError) or \
+            (exception.response["Error"]["Code"] in ['InvalidInstanceID.NotFound'])
 
     @retry(retry_on_exception=_is_retryable_exception, stop_max_delay=10000, wait_exponential_multiplier=500, wait_exponential_max=2000)
     def _find_instance_status(self, instance_id):


### PR DESCRIPTION
The EC2 API has a bug where the instance is started but cannot be tagged for a second. This fixes that bug by retrying the API calls in that specific error is returned.
